### PR TITLE
Fix: Multiple pause

### DIFF
--- a/src/SimpleTween.js
+++ b/src/SimpleTween.js
@@ -403,7 +403,7 @@
 			this._pausedTime.start = SimpleSynchro.getTime() - this._time;
 			this.dispatch("onPause");
 		} else {
-			this._pausedTime.end = (SimpleSynchro.getTime() - this._time) - this._pausedTime.start;
+			this._pausedTime.end += (SimpleSynchro.getTime() - this._time) - this._pausedTime.start;
 			
 			if(this._css && !this.useJS) { 
 				this._isRunning = false;


### PR DESCRIPTION
When the animation paused and resumed multiple times, the time calculation was out of sync and the animation jumped forward as the calculation lost the old _pauseTime.end-s
